### PR TITLE
Add Oracle DB query demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,1 +1,19 @@
 This folder contains demo materials.
+
+## run_oracle_query.py
+
+`run_oracle_query.py` demonstrates how to connect to a local Oracle database using the [`oracledb`](https://python-oracledb.readthedocs.io/) driver. The SQL statement to execute is provided as a command line argument.
+
+Environment variables are used for connection details:
+
+- `ORACLE_USER`
+- `ORACLE_PASSWORD`
+- `ORACLE_HOST` (default `localhost`)
+- `ORACLE_PORT` (default `1521`)
+- `ORACLE_SERVICE` (default `XE`)
+
+### Example
+
+```bash
+python run_oracle_query.py "SELECT * FROM my_table"
+```

--- a/demo/run_oracle_query.py
+++ b/demo/run_oracle_query.py
@@ -1,0 +1,31 @@
+import os
+import argparse
+
+# Use the thin client from the `oracledb` package
+import oracledb
+
+
+def get_connection():
+    """Create a connection using environment variables."""
+    user = os.getenv("ORACLE_USER", "user")
+    password = os.getenv("ORACLE_PASSWORD", "password")
+    host = os.getenv("ORACLE_HOST", "localhost")
+    port = os.getenv("ORACLE_PORT", "1521")
+    service = os.getenv("ORACLE_SERVICE", "XE")
+    dsn = f"{host}:{port}/{service}"
+    return oracledb.connect(user=user, password=password, dsn=dsn)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a SQL statement against a local Oracle DB")
+    parser.add_argument("sql", help="SQL query to execute")
+    args = parser.parse_args()
+
+    with get_connection() as connection:
+        with connection.cursor() as cursor:
+            for row in cursor.execute(args.sql):
+                print(row)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small demo script to run SQL against a local Oracle DB using the `oracledb` driver
- document usage of the new script in `demo/README.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c16595ec0832b82472c7f7ed502e6